### PR TITLE
Compile with Cargos release profile (with optimisations)

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -102,9 +102,9 @@ if [ -f "$1/Cargo.toml" ]; then
   echo "-----> Building application using Cargo"
 
   cd "$1"
-  # To debug git issues: 
+  # To debug git issues:
   #export RUST_LOG="cargo::sources::git=debug"
-  HOME="$cargo_home" cargo build --verbose
+  HOME="$cargo_home" cargo build --verbose --release
 else
   # Build the actual application using Make.
   echo "-----> Building application using Make"


### PR DESCRIPTION
An alternative would be that we could use Cargo's `profile` options to look for a heroku/production profile, but I think it's better to rely on the default release profile and the user can modify that if they want to customise.
