### PR TITLE
Fix missing rust libs problems, improve caching and refactor compile steps

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -1,0 +1,24 @@
+error() {
+  echo " !     $*" >&2
+  exit 1
+}
+
+status() {
+  echo "-----> $*"
+}
+
+protip() {
+  echo
+  echo "PRO TIP: $*" | indent
+  echo
+}
+
+# sed -l basically makes sed replace and buffer through stdin to stdout
+# so you get updates while the command runs and dont wait for the end
+indent() {
+  c='s/^/       /'
+  case $(uname) in
+    Darwin) sed -l "$c";; # mac/bsd sed: -l buffers on line boundaries
+    *)      sed -u "$c";; # unix/gnu sed: -u unbuffered (arbitrary) chunks of data
+  esac
+}

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -1,3 +1,10 @@
+step() {
+  local name=$1
+  shift
+
+  source $bp_dir/bin/steps/$name
+}
+
 error() {
   echo " !     $*" >&2
   exit 1

--- a/bin/compile
+++ b/bin/compile
@@ -95,9 +95,14 @@ status "Setting default LD_LIBRARY_PATH"
 mkdir -p $build_dir/.profile.d
 cat > $build_dir/.profile.d/rust_link_path.sh <<EOF
 # add rustc and project libs to LD_LIBRARY_PATH
-LD_LIBRARY_PATH=./target/release/deps/:./target/release/native/:./rustlib/:\$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=./target/release/deps/:./target/release/native/:./rustlib/:\$LD_LIBRARY_PATH
 EOF
 
+if [ -d "$cache_dir/app-cache" ]; then
+  status "Using cached build artifacts to speedup incremental build"
+  [[ -d "$build_dir/target" ]] && rm -r $build_dir/target
+  cp -r $cache_dir/app-cache $build_dir/target
+fi
 
 if [ -f "$build_dir/Cargo.toml" ]; then
   if [ -d cargo-cache-$CARGO_VERSION ]; then
@@ -124,7 +129,8 @@ if [ -f "$build_dir/Cargo.toml" ]; then
   # Make sure we have a fake home directory for the Cargo cache.  Ideally
   # we would keep these in our cache, but our ".git" directories don't
   # survive between builds.
-  cargo_home="$(mktemp -d -t cargo_XXXX)"
+  cargo_home="$cache_dir/cargo-home"
+  mkdir -p $cargo_home
 
   # Build the actual application using Cargo.
   status "Building application using Cargo"
@@ -139,3 +145,7 @@ else
   cd "$build_dir"
   make | indent
 fi
+
+status "Caching build artifacts"
+[[ -d "$cache_dir/app-cache" ]] && rm -r $cache_dir/app-cache
+cp -r target $cache_dir/app-cache

--- a/bin/compile
+++ b/bin/compile
@@ -1,33 +1,49 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+set -e              # fail fast
+set -o pipefail     # dont ignore errors when piping
+# set -x            # enable debugging
+
+# Configure directories
+build_dir=$1
+cache_dir=$2
+env_dir=$3
+bp_dir=$(cd $(dirname $0); cd ..; pwd)
+
+# Load some convenience functions like status(), error(), protip() and indent()
+source $bp_dir/bin/common.sh
 
 # Load our configuration variables.
-. "$1/RustConfig"
+if [ -f "$build_dir/RustConfig" ]; then
+  . "$build_dir/RustConfig"
+else
+  protip "Create RustConfig file and specify URL to point to a Rust and (optionally) Cargo bindary tarball."
+  error "failed: No RustConfig file was found"
+fi
 
 # Check our configuration options.
 if [ -z "$URL" ]; then
-  echo "failed: RustConfig must set URL to point to a Rust binary tarball."
-  exit 1
+  error "failed: RustConfig must set URL to point to a Rust binary tarball."
 fi
 if [ -z "$VERSION" ]; then
-  echo "failed: RustConfig must set VERSION to indicate the Rust version."
-  exit 1
+  error "failed: RustConfig must set VERSION to indicate the Rust version."
 fi
 
 # Check our Cargo configuration options if we have Cargo.toxml.
-if [ -f "$1/Cargo.toml" ]; then
+if [ -f "$build_dir/Cargo.toml" ]; then
+  status "info: Found Cargo.toml, using it to build project."
+
   if [ -z "$CARGO_URL" ]; then
-    echo "failed: RustConfig must set CARGO_URL to point to a Cargo binary tarball."
-    exit 1
+    error "failed: RustConfig must set CARGO_URL to point to a Cargo binary tarball."
   fi
   if [ -z "$CARGO_VERSION" ]; then
-    echo "failed: RustConfig must set CARGO_VERSION to indicate the Cargo version."
-    exit 1
+    error "failed: RustConfig must set CARGO_VERSION to indicate the Cargo version."
   fi
 fi
 
 # Switch to our cache directory.
-mkdir -p "$2"
-cd "$2"
+mkdir -p "$cache_dir"
+cd "$cache_dir"
 
 # Work around https://github.com/rust-lang/cargo/issues/598 on Ubuntu 10.04.
 export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
@@ -35,61 +51,73 @@ export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 # Make sure we have the C++ runtime libraries required by the Rust nightly
 # builds.
 if [ -f lib/libstdc++.so.6.0.18 ]; then
-  echo "-----> Using libstdc++.so.6.0.18"
+  status "Using libstdc++.so.6.0.18"
 else
-  echo "-----> Downloading rust-support"
+  status "Downloading rust-support"
   rm -rf lib
   curl -O https://s3.amazonaws.com/rust-builds/rust-support.tar.gz
   tar xzvf rust-support.tar.gz
 fi
-LD_LIBRARY_PATH="$2/lib:$LD_LIBRARY_PATH"
+LD_LIBRARY_PATH="$cache_dir/lib:$LD_LIBRARY_PATH"
 export LD_LIBRARY_PATH
 
 # Make sure we have the correct Rust binaries and set up PATH.
 if [ -d rust-cache-$VERSION ]; then
-  echo "-----> Using Rust version $VERSION"
+  status "Using Rust version $VERSION"
 else
-  echo "-----> Downloading Rust version $VERSION binaries from $URL"
+  status "Downloading Rust version $VERSION binaries from $URL"
 
   rm -f rust.tar.gz
   rm -rf rust-cache-*
   curl -o rust.tar.gz "$URL"
 
-  echo "-----> Extracting Rust binaries"
+  status "Extracting Rust binaries"
 
   mkdir rust-cache-$VERSION
   tar xzf rust.tar.gz -C rust-cache-$VERSION
   rm -r rust.tar.gz
 fi
-rust_path=`ls -1d "$2/rust-cache-$VERSION/"*"/"`
+rust_path=`ls -1d "$cache_dir/rust-cache-$VERSION/"*"/"`
 if [ ! -x "$rust_path/bin/rustc" ]; then
-    echo "failed: Cannot find rust binaries at $rust_path/bin"
-    exit 1
+    error "failed: Cannot find rust binaries at $rust_path/bin"
 fi
 PATH="$rust_path/bin:$PATH"
 LD_LIBRARY_PATH="$rust_path/lib:$LD_LIBRARY_PATH"
-echo $LD_LIBRARY_PATH
+echo $LD_LIBRARY_PATH | indent
 
-if [ -f "$1/Cargo.toml" ]; then
+# Make sure that our final slug has all required libs from rust
+status "Copying rustlib files"
+[[ -d "$build_dir/rustlib" ]] && rm -r "$build_dir/rustlib"
+cp -r "$rust_path/lib" "$build_dir/rustlib"
+
+# Make sure that LD_LIBRARY_PATH when slug is run points to these libs
+status "Setting default LD_LIBRARY_PATH"
+mkdir -p $build_dir/.profile.d
+cat > $build_dir/.profile.d/rust_link_path.sh <<EOF
+# add rustc and project libs to LD_LIBRARY_PATH
+LD_LIBRARY_PATH=./target/release/deps/:./target/release/native/:./rustlib/:\$LD_LIBRARY_PATH
+EOF
+
+
+if [ -f "$build_dir/Cargo.toml" ]; then
   if [ -d cargo-cache-$CARGO_VERSION ]; then
-    echo "-----> Using Cargo version $CARGO_VERSION"
+    status "Using Cargo version $CARGO_VERSION"
   else
-    echo "-----> Downloading Cargo version $CARGO_VERSION binaries from $CARGO_URL"
+    status "Downloading Cargo version $CARGO_VERSION binaries from $CARGO_URL"
 
     rm -f cargo.tar.gz
     rm -rf cargo-cache-*
     curl -o cargo.tar.gz "$CARGO_URL"
 
-    echo "-----> Extracting Cargo binaries"
+    status "Extracting Cargo binaries"
 
     mkdir cargo-cache-$CARGO_VERSION
     tar xzf cargo.tar.gz -C cargo-cache-$CARGO_VERSION
     rm -r cargo.tar.gz
   fi
-  cargo_path=`ls -1d "$2/cargo-cache-$CARGO_VERSION/"*"/bin"`
+  cargo_path=`ls -1d "$cache_dir/cargo-cache-$CARGO_VERSION/"*"/bin"`
   if [ ! -x "$cargo_path/cargo" ]; then
-      echo "failed: Cannot find cargo binaries at $cargo_path"
-      exit 1
+      error "failed: Cannot find cargo binaries at $cargo_path"
   fi
   PATH="$cargo_path:$PATH"
 
@@ -99,15 +127,15 @@ if [ -f "$1/Cargo.toml" ]; then
   cargo_home="$(mktemp -d -t cargo_XXXX)"
 
   # Build the actual application using Cargo.
-  echo "-----> Building application using Cargo"
+  status "Building application using Cargo"
 
-  cd "$1"
+  cd "$build_dir"
   # To debug git issues:
   #export RUST_LOG="cargo::sources::git=debug"
-  HOME="$cargo_home" cargo build --verbose --release
+  HOME="$cargo_home" cargo build --verbose --release | indent
 else
   # Build the actual application using Make.
-  echo "-----> Building application using Make"
-  cd "$1"
-  make
+  status "Building application using Make"
+  cd "$build_dir"
+  make | indent
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -1,151 +1,29 @@
 #!/usr/bin/env bash
 
-set -e              # fail fast
-set -o pipefail     # dont ignore errors when piping
-# set -x            # enable debugging
-
-# Configure directories
-build_dir=$1
-cache_dir=$2
-env_dir=$3
+# Load some convenience functions like status(), error(), protip(), step() and
+# indent()
 bp_dir=$(cd $(dirname $0); cd ..; pwd)
-
-# Load some convenience functions like status(), error(), protip() and indent()
 source $bp_dir/bin/common.sh
 
-# Load our configuration variables.
-if [ -f "$build_dir/RustConfig" ]; then
-  . "$build_dir/RustConfig"
-else
-  protip "Create RustConfig file and specify URL to point to a Rust and (optionally) Cargo bindary tarball."
-  error "failed: No RustConfig file was found"
-fi
+step init $1 $2 $3
 
-# Check our configuration options.
-if [ -z "$URL" ]; then
-  error "failed: RustConfig must set URL to point to a Rust binary tarball."
-fi
-if [ -z "$VERSION" ]; then
-  error "failed: RustConfig must set VERSION to indicate the Rust version."
-fi
+step load_config
+step workaround_ssl
 
-# Check our Cargo configuration options if we have Cargo.toxml.
-if [ -f "$build_dir/Cargo.toml" ]; then
-  status "info: Found Cargo.toml, using it to build project."
+step switch_to_cache
+step install_libc
+step install_rust
 
-  if [ -z "$CARGO_URL" ]; then
-    error "failed: RustConfig must set CARGO_URL to point to a Cargo binary tarball."
-  fi
-  if [ -z "$CARGO_VERSION" ]; then
-    error "failed: RustConfig must set CARGO_VERSION to indicate the Cargo version."
-  fi
-fi
+step setup_libs
 
-# Switch to our cache directory.
-mkdir -p "$cache_dir"
-cd "$cache_dir"
-
-# Work around https://github.com/rust-lang/cargo/issues/598 on Ubuntu 10.04.
-export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
-
-# Make sure we have the C++ runtime libraries required by the Rust nightly
-# builds.
-if [ -f lib/libstdc++.so.6.0.18 ]; then
-  status "Using libstdc++.so.6.0.18"
-else
-  status "Downloading rust-support"
-  rm -rf lib
-  curl -O https://s3.amazonaws.com/rust-builds/rust-support.tar.gz
-  tar xzvf rust-support.tar.gz
-fi
-LD_LIBRARY_PATH="$cache_dir/lib:$LD_LIBRARY_PATH"
-export LD_LIBRARY_PATH
-
-# Make sure we have the correct Rust binaries and set up PATH.
-if [ -d rust-cache-$VERSION ]; then
-  status "Using Rust version $VERSION"
-else
-  status "Downloading Rust version $VERSION binaries from $URL"
-
-  rm -f rust.tar.gz
-  rm -rf rust-cache-*
-  curl -o rust.tar.gz "$URL"
-
-  status "Extracting Rust binaries"
-
-  mkdir rust-cache-$VERSION
-  tar xzf rust.tar.gz -C rust-cache-$VERSION
-  rm -r rust.tar.gz
-fi
-rust_path=`ls -1d "$cache_dir/rust-cache-$VERSION/"*"/"`
-if [ ! -x "$rust_path/bin/rustc" ]; then
-    error "failed: Cannot find rust binaries at $rust_path/bin"
-fi
-PATH="$rust_path/bin:$PATH"
-LD_LIBRARY_PATH="$rust_path/lib:$LD_LIBRARY_PATH"
-echo $LD_LIBRARY_PATH | indent
-
-# Make sure that our final slug has all required libs from rust
-status "Copying rustlib files"
-[[ -d "$build_dir/rustlib" ]] && rm -r "$build_dir/rustlib"
-cp -r "$rust_path/lib" "$build_dir/rustlib"
-
-# Make sure that LD_LIBRARY_PATH when slug is run points to these libs
-status "Setting default LD_LIBRARY_PATH"
-mkdir -p $build_dir/.profile.d
-cat > $build_dir/.profile.d/rust_link_path.sh <<EOF
-# add rustc and project libs to LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=./target/release/deps/:./target/release/native/:./rustlib/:\$LD_LIBRARY_PATH
-EOF
-
-if [ -d "$cache_dir/app-cache" ]; then
-  status "Using cached build artifacts to speedup incremental build"
-  [[ -d "$build_dir/target" ]] && rm -r $build_dir/target
-  cp -r $cache_dir/app-cache $build_dir/target
-fi
+step use_cached_build_artifacts
 
 if [ -f "$build_dir/Cargo.toml" ]; then
-  if [ -d cargo-cache-$CARGO_VERSION ]; then
-    status "Using Cargo version $CARGO_VERSION"
-  else
-    status "Downloading Cargo version $CARGO_VERSION binaries from $CARGO_URL"
+  step install_cargo
 
-    rm -f cargo.tar.gz
-    rm -rf cargo-cache-*
-    curl -o cargo.tar.gz "$CARGO_URL"
-
-    status "Extracting Cargo binaries"
-
-    mkdir cargo-cache-$CARGO_VERSION
-    tar xzf cargo.tar.gz -C cargo-cache-$CARGO_VERSION
-    rm -r cargo.tar.gz
-  fi
-  cargo_path=`ls -1d "$cache_dir/cargo-cache-$CARGO_VERSION/"*"/bin"`
-  if [ ! -x "$cargo_path/cargo" ]; then
-      error "failed: Cannot find cargo binaries at $cargo_path"
-  fi
-  PATH="$cargo_path:$PATH"
-
-  # Make sure we have a fake home directory for the Cargo cache.  Ideally
-  # we would keep these in our cache, but our ".git" directories don't
-  # survive between builds.
-  cargo_home="$cache_dir/cargo-home"
-  mkdir -p $cargo_home
-
-  # Build the actual application using Cargo.
-  status "Building application using Cargo"
-
-  cd "$build_dir"
-  # To debug git issues:
-  #export RUST_LOG="cargo::sources::git=debug"
-  HOME="$cargo_home" cargo build --verbose --release | indent
+  step build_with_cargo
 else
-  # Build the actual application using Make.
-  status "Building application using Make"
-  cd "$build_dir"
-  make | indent
+  step build_with_make
 fi
 
-status "Caching build artifacts"
-[[ -d "$cache_dir/app-cache" ]] && rm -r $cache_dir/app-cache
-cp -r target $cache_dir/app-cache
+step cache_build_artifacts

--- a/bin/release
+++ b/bin/release
@@ -1,16 +1,4 @@
 #!/usr/bin/env bash
-
-set -e              # fail fast
-set -o pipefail     # dont ignore errors when piping
-# set -x            # enable debugging
-
-# Configure directories
-build_dir=$1
-bp_dir=$(cd $(dirname $0); cd ..; pwd)
-
-# Load some convenience functions like status(), error(), protip() and indent()
-source $bp_dir/bin/common.sh
-
 cat << EOF
 ---
 addons: []

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e              # fail fast
+set -o pipefail     # dont ignore errors when piping
+# set -x            # enable debugging
+
+# Configure directories
+build_dir=$1
+bp_dir=$(cd $(dirname $0); cd ..; pwd)
+
+# Load some convenience functions like status(), error(), protip() and indent()
+source $bp_dir/bin/common.sh
+
+cat << EOF
+---
+addons: []
+default_process_types:
+  web: cargo run --release
+EOF

--- a/bin/steps/build_with_cargo
+++ b/bin/steps/build_with_cargo
@@ -1,0 +1,10 @@
+cargo_home="$cache_dir/cargo-home"
+mkdir -p $cargo_home
+
+# Build the actual application using Cargo.
+status "Building application using Cargo"
+
+cd "$build_dir"
+# To debug git issues:
+#export RUST_LOG="cargo::sources::git=debug"
+HOME="$cargo_home" cargo build --verbose --release | indent

--- a/bin/steps/build_with_make
+++ b/bin/steps/build_with_make
@@ -1,0 +1,4 @@
+# Build the actual application using Make.
+status "Building application using Make"
+cd "$build_dir"
+make | indent

--- a/bin/steps/cache_build_artifacts
+++ b/bin/steps/cache_build_artifacts
@@ -1,0 +1,3 @@
+status "Caching build artifacts"
+[[ -d "$cache_dir/app-cache" ]] && rm -r $cache_dir/app-cache
+cp -r target $cache_dir/app-cache

--- a/bin/steps/init
+++ b/bin/steps/init
@@ -1,0 +1,7 @@
+set -e              # fail fast
+set -o pipefail     # dont ignore errors when piping
+# set -x            # enable debugging
+
+build_dir=$1
+cache_dir=$2
+env_dir=$3

--- a/bin/steps/install_cargo
+++ b/bin/steps/install_cargo
@@ -1,0 +1,20 @@
+if [ -d cargo-cache-$CARGO_VERSION ]; then
+  status "Using Cargo version $CARGO_VERSION"
+else
+  status "Downloading Cargo version $CARGO_VERSION binaries from $CARGO_URL"
+
+  rm -f cargo.tar.gz
+  rm -rf cargo-cache-*
+  curl -o cargo.tar.gz "$CARGO_URL"
+
+  status "Extracting Cargo binaries"
+
+  mkdir cargo-cache-$CARGO_VERSION
+  tar xzf cargo.tar.gz -C cargo-cache-$CARGO_VERSION
+  rm -r cargo.tar.gz
+fi
+cargo_path=`ls -1d "$cache_dir/cargo-cache-$CARGO_VERSION/"*"/bin"`
+if [ ! -x "$cargo_path/cargo" ]; then
+    error "failed: Cannot find cargo binaries at $cargo_path"
+fi
+PATH="$cargo_path:$PATH"

--- a/bin/steps/install_libc
+++ b/bin/steps/install_libc
@@ -1,0 +1,12 @@
+# Make sure we have the C++ runtime libraries required by the Rust nightly
+# builds.
+if [ -f lib/libstdc++.so.6.0.18 ]; then
+  status "Using libstdc++.so.6.0.18"
+else
+  status "Downloading rust-support"
+  rm -rf lib
+  curl -O https://s3.amazonaws.com/rust-builds/rust-support.tar.gz
+  tar xzvf rust-support.tar.gz
+fi
+LD_LIBRARY_PATH="$cache_dir/lib:$LD_LIBRARY_PATH"
+export LD_LIBRARY_PATH

--- a/bin/steps/install_rust
+++ b/bin/steps/install_rust
@@ -1,0 +1,23 @@
+# Make sure we have the correct Rust binaries and set up PATH.
+if [ -d rust-cache-$VERSION ]; then
+  status "Using Rust version $VERSION"
+else
+  status "Downloading Rust version $VERSION binaries from $URL"
+
+  rm -f rust.tar.gz
+  rm -rf rust-cache-*
+  curl -o rust.tar.gz "$URL"
+
+  status "Extracting Rust binaries"
+
+  mkdir rust-cache-$VERSION
+  tar xzf rust.tar.gz -C rust-cache-$VERSION
+  rm -r rust.tar.gz
+fi
+rust_path=`ls -1d "$cache_dir/rust-cache-$VERSION/"*"/"`
+if [ ! -x "$rust_path/bin/rustc" ]; then
+    error "failed: Cannot find rust binaries at $rust_path/bin"
+fi
+PATH="$rust_path/bin:$PATH"
+LD_LIBRARY_PATH="$rust_path/lib:$LD_LIBRARY_PATH"
+echo $LD_LIBRARY_PATH | indent

--- a/bin/steps/load_config
+++ b/bin/steps/load_config
@@ -1,0 +1,28 @@
+# Load our configuration variables.
+if [ -f "$build_dir/RustConfig" ]; then
+  . "$build_dir/RustConfig"
+else
+  protip "Create RustConfig file and specify URL to point to a Rust and (optionally) Cargo bindary tarball."
+  error "failed: No RustConfig file was found"
+fi
+
+# Check our configuration options.
+if [ -z "$URL" ]; then
+  error "failed: RustConfig must set URL to point to a Rust binary tarball."
+fi
+if [ -z "$VERSION" ]; then
+  error "failed: RustConfig must set VERSION to indicate the Rust version."
+fi
+
+# Check our Cargo configuration options if we have Cargo.toxml.
+if [ -f "$build_dir/Cargo.toml" ]; then
+  status "info: Found Cargo.toml, using it to build project."
+
+  if [ -z "$CARGO_URL" ]; then
+    error "failed: RustConfig must set CARGO_URL to point to a Cargo binary tarball."
+  fi
+  if [ -z "$CARGO_VERSION" ]; then
+    error "failed: RustConfig must set CARGO_VERSION to indicate the Cargo version."
+  fi
+fi
+

--- a/bin/steps/setup_libs
+++ b/bin/steps/setup_libs
@@ -1,0 +1,12 @@
+# Make sure that our final slug has all required libs from rust
+status "Copying rustlib files"
+[[ -d "$build_dir/rustlib" ]] && rm -r "$build_dir/rustlib"
+cp -r "$rust_path/lib" "$build_dir/rustlib"
+
+# Make sure that LD_LIBRARY_PATH when slug is run points to these libs
+status "Setting default LD_LIBRARY_PATH"
+mkdir -p $build_dir/.profile.d
+cat > $build_dir/.profile.d/rust_link_path.sh <<EOF
+# add rustc and project libs to LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=./target/release/deps/:./target/release/native/:./rustlib/:\$LD_LIBRARY_PATH
+EOF

--- a/bin/steps/switch_to_cache
+++ b/bin/steps/switch_to_cache
@@ -1,0 +1,3 @@
+# Switch to our cache directory.
+mkdir -p "$cache_dir"
+cd "$cache_dir"

--- a/bin/steps/use_cached_build_artifacts
+++ b/bin/steps/use_cached_build_artifacts
@@ -1,0 +1,5 @@
+if [ -d "$cache_dir/app-cache" ]; then
+  status "Using cached build artifacts to speedup incremental build"
+  [[ -d "$build_dir/target" ]] && rm -r $build_dir/target
+  cp -r $cache_dir/app-cache $build_dir/target
+fi

--- a/bin/steps/workaround_ssl
+++ b/bin/steps/workaround_ssl
@@ -1,0 +1,2 @@
+# Work around https://github.com/rust-lang/cargo/issues/598 on Ubuntu 10.04.
+export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
- I had a problem when running compiled app on heroku: it wasn't able to find `libnative` library which is a part of rustc libs directory. After inspecting a slug I understood, that it has no build cache when dyno is running. Resolved issue by copying these libs inside of build directory and sourcing proper `LD_LIBRARY_PATH`.
- It was a pain to wait for dependencies to be re-downloaded through git and rebuilt from scratch at each deploy. So I put build artifacts (`target` and `$cargo_home`) to cache, and on next builds reusing it, so `Cargo` can decide what to download and what to rebuild on any updates in `Cargo.lock` file. Turns out that `.git` folders in cache survive between build perfectly.
- Since `bin/compile` is too bloated, I have refactored it to different `bin/steps/*` and call them from `bin/compile`.