### PR TITLE
Export Rust build environment for use by other buildpacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.vagrant/
 /cache/
 /heroku-rust-cargo-hello/
+/export

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ fall of 2016.  Features include:
 - Caching of builds between deployments.
 - Automatic updates to the latest stable Rust by default.
 - Optional pinning of Rust to a specific version.
+- Support for `export` so that other buildpacks can access the Rust
+  toolchain.
 
 For an example project, see [heroku-rust-cargo-hello][].
 

--- a/README.md
+++ b/README.md
@@ -59,9 +59,10 @@ VERSION=1.11
 
 If you need to tweak this buildpack, the following information may help.
 
-### Testing with Vagrant
+### Testing with Docker
 
-To test changes to the buildpack using the included `Vagrantfile`, run:
+To test changes to the buildpack using the included
+`docker-compose-test.yml`, run:
 
 ```sh
 ./test_buildpack

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ fall of 2016.  Features include:
 - Optional pinning of Rust to a specific version.
 - Support for `export` so that other buildpacks can access the Rust
   toolchain.
+- Support for compiling Rust-based extensions for projects written
+  in other languages.
 
 For an example project, see [heroku-rust-cargo-hello][].
 
@@ -55,6 +57,30 @@ VERSION=nightly
 
 ```sh
 VERSION=1.11
+```
+
+## Combining with other buildpacks
+
+If you have a project which combines both Rust and another programming
+language, you can insert this buildpack before your existing one as
+follows:
+
+```sh
+heroku buildpacks:add --index 1 https://github.com/emk/heroku-buildpack-rust.git
+```
+
+If you have a valid `Cargo.toml` in your project, this is all you need to
+do.  The Rust buildpack will run first, and your existing buildpack will
+run second.
+
+
+But if you only need Rust to build a particular Ruby gem, and you have no
+top-level `Cargo.toml` file, you'll need to let the buildpack know to skip
+the build stage.  You can do this by adding the following line to
+`RustConfig`:
+
+```sh
+RUST_SKIP_BUILD=1
 ```
 
 ## Development notes

--- a/bin/compile
+++ b/bin/compile
@@ -1,12 +1,19 @@
 #!/bin/bash
 
+# Find all the directories we might need (based on
+# heroku-buildpack-nodejs code).
+BUILD_DIR=${1:-}
+CACHE_DIR=${2:-}
+ENV_DIR=${3:-}
+BP_DIR=$(cd $(dirname ${0:-}); cd ..; pwd)
+
 # Set defaults for our configuration variables.  Stable Rust is sufficiently
 # stable at this point that I think we can just default it.
 VERSION=stable
 
 # Load our configuration variables, if any were specified.
-if [ -f "$1/RustConfig" ]; then
-    . "$1/RustConfig"
+if [ -f "$BUILD_DIR/RustConfig" ]; then
+    . "$BUILD_DIR/RustConfig"
 fi
 
 # Standard paranoia.
@@ -20,7 +27,7 @@ fi
 
 # Notify users running old, unstable versions of Rust about how to deploy
 # successfully.
-if [ ! -z ${CARGO_URL+x} ] || [ ! -f "$1/Cargo.toml" ]; then
+if [ ! -z ${CARGO_URL+x} ] || [ ! -f "$BUILD_DIR/Cargo.toml" ]; then
     >&2 cat <<EOF
 To deploy a modern Rust app, make sure you have a Cargo.toml file, and that
 you do not define CARGO_URL or CARGO_VERSION in RustConfig.  If you're
@@ -42,23 +49,29 @@ EOF
     exit 1
 fi
 
-# Switch to our cache directory.
-mkdir -p "$2"
-cd "$2"
+# Record our Rust build environment configuration in an export file, in
+# case another buildpack needs it to build Ruby gems that use Rust or
+# something like that.
+cat <<EOF > $BP_DIR/export
+# Our rustup installation.
+export RUSTUP_HOME="$CACHE_DIR/multirust"
 
-# Rustup wants to create `~/.multirust` and fill it with toolchains.  If we
-# set $HOME to our cache directory, it will do the right thing.
-export HOME="`pwd`"
-
-# This is where we will cache our downloaded compilers, as well as git
-# repositories downloaded by Cargo.  We implicitly trust Rustup and Cargo
+# Our cargo installation.  We implicitly trust Rustup and Cargo
 # to do the right thing when new versions are released.
-export CARGO_HOME="`pwd`/cargo"
+export CARGO_HOME="$CACHE_DIR/cargo"
 
-# Make sure we have the correct Rust binaries and set up PATH.  We don't
-# skip this step even if $RUST_HOME exists, because rustup may want to
-# update our channel.
-PATH="$CARGO_HOME/bin:$PATH"
+# Include binaries installed by cargo and rustup in our path.
+PATH="\$CARGO_HOME/bin:\$PATH"
+EOF
+
+# Read our build environment back in and evaluate it so that we can use it.
+. $BP_DIR/export
+
+# Switch to our cache directory.
+mkdir -p "$CACHE_DIR"
+cd "$CACHE_DIR"
+
+# Make sure we have an appropriate Rust toolchain installed.
 if [ -d "$CARGO_HOME" ]; then
     echo "-----> Checking for new releases of Rust $VERSION channel"
     # It's possible that $VERSION has changed, or the `stable` channel has updated.
@@ -81,7 +94,7 @@ fi
 # This is where we will cache our Rust output.  Note the suggestions at
 # https://github.com/alexcrichton/cargo/commit/014765f788ca1c2476936835ca32cc2746f99b42
 # which describe how this needs to be named.
-export CARGO_TARGET_DIR="$2/target"
+export CARGO_TARGET_DIR="$CACHE_DIR/target"
 
 # Build our project (into CARGO_TARGET_DIR so we have caching) and copy it
 # back to the source tree.  In theory, we could probably just copy the
@@ -92,7 +105,7 @@ export CARGO_TARGET_DIR="$2/target"
 #export RUST_LOG="cargo::sources::git=debug"
 # To debug compiler and linking issues, add `--verbose`.
 echo "-----> Building application using Cargo"
-cd "$1"
+cd "$BUILD_DIR"
 rm -rf target/
 cargo build --release
 cp -a "$CARGO_TARGET_DIR" target

--- a/bin/compile
+++ b/bin/compile
@@ -11,6 +11,11 @@ BP_DIR=$(cd $(dirname ${0:-}); cd ..; pwd)
 # stable at this point that I think we can just default it.
 VERSION=stable
 
+# Set this to "1" in `RustConfig` to just install a Rust toolchain and not
+# build `Cargo.toml`.  This is useful if you have a project written in Ruby
+# or Node (for example) that needs to build extension modules using Rust.
+RUST_SKIP_BUILD=0
+
 # Load our configuration variables, if any were specified.
 if [ -f "$BUILD_DIR/RustConfig" ]; then
     . "$BUILD_DIR/RustConfig"


### PR DESCRIPTION
See #9.  The theory here is that we might have a Ruby application that
uses a gem implemented in Rust, and in order to compile the gem, the
Ruby buildpack needs access to the Rust compiler.

To support this, we need to create an `export` file in our buildpack
directory containing all the environment variables needed to run `cargo`
and `rustc`.

Note that this still has some limitations: You almost certainly need to
have a valid `Cargo.toml` in your project for the buildpack to detect
and build before you can run the other buildpack that needs Rust.

--
- CC @binarycleric Feel free to take a look at this and let me know what you think.
- CC @schneems @elifoster Please let me know if this works for your use cases.

To try this, I think you can run `heroku buildpacks:set https://github.com/emk/heroku-buildpack-rust#multirust_export` and redeploy. But please set it back when you're done, because I'll delete the branch when I merge it.