### PR TITLE
Avoid copying non-executable files into BUILD_DIR

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -119,7 +119,8 @@ if [ $RUST_SKIP_BUILD -ne 1 ]; then
   cd "$BUILD_DIR"
   rm -rf target/
   cargo build --release
-  cp -a "$CARGO_TARGET_DIR" target
+  mkdir -p target/release
+  find "$CARGO_TARGET_DIR/release" -maxdepth 1 -type f -executable -exec cp -a -t target/release {} \;
 else
   echo "-----> Skipping Cargo build"
 fi


### PR DESCRIPTION
This does not rely upon any Rust toolchain support, but rather upon the good old `find` program. Thus, it copies *all* executables in `$CARGO_TARGET_DIR/release`, rather than any specifically-named executable file.

In short, this is a somewhat hacky method for circumnavigating #17.
