### PR TITLE
only export DATABASE_URL if the env var exists

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -10,7 +10,9 @@ BP_DIR=$(cd $(dirname ${0:-}); cd ..; pwd)
 # Export DATABASE_URL at build time, mostly because Diesel is the best way to
 # do SQL in Rust right now, and Diesel will use it to generated code for the
 # database schema.
-export DATABASE_URL="$(cat $ENV_DIR/DATABASE_URL)";
+if [ -e "$ENV_DIR/DATABASE_URL" ]; then
+  export DATABASE_URL="$(cat $ENV_DIR/DATABASE_URL)";
+fi
 
 # Set defaults for our configuration variables.  Stable Rust is sufficiently
 # stable at this point that I think we can just default it.


### PR DESCRIPTION
If you aren't using a DATABASE, you currently see:

```
remote: cat: /tmp/d20170417-65-omte7i/DATABASE_URL: No such file or directory
```

This check only exports `DATABASE_URL` if the file exists.