### PR TITLE
Use rust-toolchain instead of RustConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,19 +60,12 @@ Normally, this is pretty safe: New stable Rust releases have excellent
 backwards compatibility.
 
 But you may wish to use `nightly` Rust or to lock your Rust version to a
-known-good configuration for more reproducible builds.  To do this, create
-a top-level file named `RustConfig` in your project specifying either a
-channel name:
+known-good configuration for more reproducible builds. To specify a specific
+version of the toolchain, use a [`rust-toolchain`](https://github.com/rust-lang-nursery/rustup.rs#the-toolchain-file) file in the format rustup
+uses.
 
-```sh
-VERSION=nightly
-```
-
-...or a specific version:
-
-```sh
-VERSION=1.20.0
-```
+Note: if you previously specified a `VERSION` variable in `RustConfig`, that will continue to work,
+and will override a `rust-toolchain` file.
 
 ## Combining with other buildpacks
 

--- a/bin/compile
+++ b/bin/compile
@@ -26,6 +26,11 @@ RUST_SKIP_BUILD=0
 # `BUILD_PATH` to the correct directory in the `RustConfig`
 BUILD_PATH=""
 
+# Load our toolchain configuration, if any was specified.
+if [ -f "$BUILD_DIR/rust-toolchain" ]; then
+    VERSION=$(cat $BUILD_DIR/rust-toolchain)
+fi
+
 # Load our configuration variables, if any were specified.
 if [ -f "$BUILD_DIR/RustConfig" ]; then
     . "$BUILD_DIR/RustConfig"
@@ -36,7 +41,7 @@ set -eu
 
 # Check our configuration options.
 if [ -z ${VERSION+x} ]; then
-  >&2 echo "failed: RustConfig must set VERSION to indicate the Rust version."
+  >&2 echo "failed: must set VERSION with rust-toolchain or RustConfig to indicate the Rust version."
   exit 1
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -28,7 +28,7 @@ BUILD_PATH=""
 
 # Load our toolchain configuration, if any was specified.
 if [ -f "$BUILD_DIR/rust-toolchain" ]; then
-    VERSION=$(cat $BUILD_DIR/rust-toolchain)
+    VERSION="$(cat $BUILD_DIR/rust-toolchain)"
 fi
 
 # Load our configuration variables, if any were specified.

--- a/bin/compile
+++ b/bin/compile
@@ -28,7 +28,7 @@ BUILD_PATH=""
 
 # Load our toolchain configuration, if any was specified.
 if [ -f "$BUILD_DIR/rust-toolchain" ]; then
-    VERSION="$(cat $BUILD_DIR/rust-toolchain)"
+    VERSION="$(cat "$BUILD_DIR/rust-toolchain")"
 fi
 
 # Load our configuration variables, if any were specified.

--- a/bin/detect
+++ b/bin/detect
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ -f "$1/RustConfig" ] || [ -f "$1/Cargo.toml" ]; then
+if [ -f "$1/RustConfig" ] || [ -f "$1/rust-toolchain" ] || [ -f "$1/Cargo.toml" ]; then
     echo "Rust"
     exit 0
 else


### PR DESCRIPTION
Something pretty similar to this is currently powering rusty-dash.com after I moved it over to Heroku last night/this morning. I think it should be backwards compatible with RustConfig's VERSION setup as well.

Fixes https://github.com/emk/heroku-buildpack-rust/issues/11