### PR TITLE
Add a release script

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 echo "---
 default_process_types:
-  web: cargo run --release"
+  web: cargo run"

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+echo "---
+default_process_types:
+  web: cargo run"

--- a/bin/release
+++ b/bin/release
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 echo "---
 default_process_types:
-  web: cargo run"
+  web: cargo run --release"


### PR DESCRIPTION
It appears that modern cloud foundry requires a simple release script in order to run.