### PR TITLE
Add a flag to install the diesel CLI at build time

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,22 @@ To deploy your application, run:
 git push heroku master
 ```
 
+### Running Diesel migrations during the release phase
+
+This will install the diesel CLI at build time and make it available in your dyno.
+Migrations will run whenever a new version of your app is released. Add the
+following line to your `RustConfig`
+
+```sh
+RUST_INSTALL_DIESEL=1
+```
+
+and this one to your `Procfile`
+
+```Procfile
+release: ./target/release/diesel migration run
+```
+
 [Heroku CLI]: https://devcenter.heroku.com/articles/heroku-command-line
 
 ## Specifying which version of Rust to use

--- a/bin/compile
+++ b/bin/compile
@@ -131,6 +131,11 @@ if [ $RUST_SKIP_BUILD -ne 1 ]; then
   cargo build --release
   mkdir -p target/release
   find "$CARGO_TARGET_DIR/release" -maxdepth 1 -type f -executable -exec cp -a -t target/release {} \;
+  
+  # Install diesel so we can use it for migrations
+  echo "-----> Installing diesel"
+  cargo install diesel_cli --no-default-features --features postgres || echo "already installed"
+  cp $(which diesel) target/release/
 else
   echo "-----> Skipping Cargo build"
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -147,6 +147,4 @@ if [ $RUST_INSTALL_DIESEL -eq 1 ]; then
   echo "-----> Installing diesel"
   cargo install diesel_cli $DIESEL_FLAGS || echo "already installed"
   cp $(which diesel) target/release/
-else
-  echo "-----> Skipping diesel install"
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -25,6 +25,11 @@ RUST_SKIP_BUILD=0
 # If your Rust code is not at the root directory of the repository, specify a
 # `BUILD_PATH` to the correct directory in the `RustConfig`
 BUILD_PATH=""
+# Set this to "1" in `RustConfig` to install diesel at build time and copy it
+# into the target directory, next to your app binary. This makes it easy to
+# run migrations by adding a release step to your Procfile:
+# `release: ./target/release/diesel migration run`
+RUST_INSTALL_DIESEL=0
 
 # Load our toolchain configuration, if any was specified.
 if [ -f "$BUILD_DIR/rust-toolchain" ]; then
@@ -131,11 +136,15 @@ if [ $RUST_SKIP_BUILD -ne 1 ]; then
   cargo build --release
   mkdir -p target/release
   find "$CARGO_TARGET_DIR/release" -maxdepth 1 -type f -executable -exec cp -a -t target/release {} \;
-  
-  # Install diesel so we can use it for migrations
+else
+  echo "-----> Skipping Cargo build"
+fi
+
+# Install diesel so we can use it for migrations
+if [ $RUST_INSTALL_DIESEL -eq 1 ]; then
   echo "-----> Installing diesel"
   cargo install diesel_cli --no-default-features --features postgres || echo "already installed"
   cp $(which diesel) target/release/
 else
-  echo "-----> Skipping Cargo build"
+  echo "-----> Skipping diesel install"
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -30,6 +30,8 @@ BUILD_PATH=""
 # run migrations by adding a release step to your Procfile:
 # `release: ./target/release/diesel migration run`
 RUST_INSTALL_DIESEL=0
+# These flags are passed to `cargo install diesel`, e.g. '--no-default-features --features postgres'
+DIESEL_FLAGS=""
 
 # Load our toolchain configuration, if any was specified.
 if [ -f "$BUILD_DIR/rust-toolchain" ]; then
@@ -143,7 +145,7 @@ fi
 # Install diesel so we can use it for migrations
 if [ $RUST_INSTALL_DIESEL -eq 1 ]; then
   echo "-----> Installing diesel"
-  cargo install diesel_cli --no-default-features --features postgres || echo "already installed"
+  cargo install diesel_cli $DIESEL_FLAGS || echo "already installed"
   cp $(which diesel) target/release/
 else
   echo "-----> Skipping diesel install"


### PR DESCRIPTION
This allows us to run diesel migrations during the release phase by shipping the diesel CLI along with the rest of your app. 