### PR TITLE
support cargo ssh keys

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -78,6 +78,8 @@ EOF
     exit 1
 fi
 
+eval "$(ssh-agent -s)" && ssh-add
+
 # Record our Rust build environment configuration in an export file, in
 # case another buildpack needs it to build Ruby gems that use Rust or
 # something like that.


### PR DESCRIPTION
This is required if you have private repos in github, otherwise Cargo can't access them. The idea is to export a machine (Github user) ssh key as env var on Heroku. This is not related to Heroku but with cargo itself, how it handles ssh keys. It was first noted by @dignifiedquire in #39 