### PR TITLE
Add option in `RustConfig` to execute scripts before or after compile

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -125,6 +125,12 @@ fi
 # which describe how this needs to be named.
 export CARGO_TARGET_DIR="$CACHE_DIR/target"
 
+# Pre-compile script
+if [[ -v RUST_PRECOMPILE ]]; then
+  echo "-----> Precompile"
+  eval $RUST_PRECOMPILE
+fi
+
 if [ $RUST_SKIP_BUILD -ne 1 ]; then
   # Build our project (into CARGO_TARGET_DIR so we have caching) and copy it
   # back to the source tree.  In theory, we could probably just copy the
@@ -149,4 +155,10 @@ if [ $RUST_INSTALL_DIESEL -eq 1 ]; then
   echo "-----> Installing diesel"
   cargo install diesel_cli $DIESEL_FLAGS || echo "already installed"
   cp $(which diesel) target/release/
+fi
+
+# Post-compile script
+if [[ -v RUST_POSTCOMPILE ]]; then
+  echo "-----> Postcompile"
+  eval $RUST_POSTCOMPILE
 fi


### PR DESCRIPTION
I added new options in RustConfig: `$RUST_PRECOMPILE` and `$RUST_POSTCOMPILE`

## My usecase

I want to deploy a webserver written in Rust to publish rustdoc for private on Heroku. It requires building rustdoc before deployment.

## Alternatives

- Using `build.rs`: Not worked, as `cargo doc` also calls build.rs, so it doesn't finish building.
- Other CI/CD tools: I cannot use Heroku pipeline function (Review Apps) fully.

So I achieved it to implement the options and add the following statement in RustConfig:

```
RUST_POSTCOMPILE='cargo doc --no-deps; cp -r $CARGO_TARGET_DIR/doc target/release/docs'
```

It works perfectly.

## Other usecases

We may want to install some apps like diesel before deployment in the future.