### PR TITLE
Allow SSH into private GH repo

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -78,6 +78,8 @@ EOF
     exit 1
 fi
 
+eval "$(ssh-agent -s)" && ssh-add
+
 # Record our Rust build environment configuration in an export file, in
 # case another buildpack needs it to build Ruby gems that use Rust or
 # something like that.


### PR DESCRIPTION
This line is one copied from a PR I found 2 years ago that never was merged. It is really awesome as it allows this buildpack to talk with a private GH repo in conjunction with this buildpack: ``https://github.com/heroku/heroku-buildpack-ssh-key.git``