### PR TITLE
Make (certain) environment variables available at build time

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ If the variable is not set in `RustConfig`, the default value will be used to bu
 
 If you want to set variables that are needed at build time, prefix the variable with ```BUILDVAR_``` when adding to Heroku Config Vars. 
 
-```$ heroku config:set BUILDVAR_API_KEY=myapikey```
+```sh
+$ heroku config:set BUILDVAR_API_KEY=myapikey
+```
 
 ## Using the edge version of the buildpack
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ RUST_CARGO_BUILD_FLAGS="--release -p some_package --bin some_exe --bin some_bin_
 The default value of `RUST_CARGO_BUILD_FLAGS` is `--release`.
 If the variable is not set in `RustConfig`, the default value will be used to build the project.
 
+## Set variables to use during build
+
+If you want to set variables that are needed at build time, prefix the variable with ```BUILDVAR_``` when adding to Heroku Config Vars. 
+
+```$ heroku config:set BUILDVAR_API_KEY=myapikey```
+
 ## Using the edge version of the buildpack
 
 The `emk/rust` buildpack from the [Heroku Registry](https://devcenter.heroku.com/articles/buildpack-registry) contains the latest stable version of the buildpack. If you'd like to use the latest buildpack code from this Github repository, you can set your buildpack to the Github URL:

--- a/bin/compile
+++ b/bin/compile
@@ -14,6 +14,21 @@ if [ -e "$ENV_DIR/DATABASE_URL" ]; then
   export DATABASE_URL="$(cat $ENV_DIR/DATABASE_URL)";
 fi
 
+## Export BUILDVAR_ variables at build time. 
+## Useful in cases where application sets variables at build time. 
+## E.g. static API_KEY: &str = env!("BUILDVAR_API_KEY");
+if ls "$ENV_DIR" 2>/dev/null | grep -q -e ^BUILDVAR_; then
+  echo "-----> Found BUILDVAR_ variable(s)"
+  for BUILDVAR in $(ls "$ENV_DIR" | grep -e ^BUILDVAR_); do
+    VAR_KEY=$BUILDVAR
+    VAR_VALUE=$(cat $ENV_DIR/$BUILDVAR)
+    echo "-----> Exporting $VAR_KEY"
+    export "$VAR_KEY=$VAR_VALUE"
+  done
+else
+  echo "-----> Found no BUILDVAR_ variable"
+fi
+
 # Set defaults for our configuration variables.  Stable Rust is sufficiently
 # stable at this point that I think we can just default it.
 VERSION=stable


### PR DESCRIPTION
Thought adding a general prefix to identify the variables wanted was simplest.
Response to issue #25.

User sets Config Var for their Heroku application using the ```BUILDVAR_``` prefix. 
These variables get exported similar to the ```DATABASE_URL``` for Diesel functionality.
```bash
$ heroku config:set BUILDVAR_KEY=mysecret
```


First time doing a contribution so please excuse but note any technical misses.
