### PR TITLE
Change "find" command to find example binaries

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -140,7 +140,6 @@ if [ $RUST_SKIP_BUILD -ne 1 ]; then
   cargo build $RUST_CARGO_BUILD_FLAGS
   mkdir -p target/release
   find "$CARGO_TARGET_DIR/release" -maxdepth 2 -type f -executable -exec cp -a -t target/release {} \;
-  ls target/release/
 else
   echo "-----> Skipping Cargo build"
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -33,7 +33,7 @@ RUST_INSTALL_DIESEL=0
 # These flags are passed to `cargo install diesel`, e.g. '--no-default-features --features postgres'
 DIESEL_FLAGS=""
 # Default build flags to pass to `cargo build`.
-RUST_CARGO_BUILD_FLAGS="--release"
+RUST_CARGO_BUILD_FLAGS="--release --example heroku-deploy"
 
 # Load our toolchain configuration, if any was specified.
 if [ -f "$BUILD_DIR/rust-toolchain" ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -138,7 +138,9 @@ if [ $RUST_SKIP_BUILD -ne 1 ]; then
   cd "$BUILD_DIR/$BUILD_PATH"
   rm -rf target/
   cargo build --release --example heroku-deploy
-  ls target/release/examples/
+  mkdir -p target/release
+  find "$CARGO_TARGET_DIR/release" -maxdepth 1 -type f -executable -exec cp -a -t target/release {} \;
+  ls target/release/
 else
   echo "-----> Skipping Cargo build"
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -139,7 +139,6 @@ if [ $RUST_SKIP_BUILD -ne 1 ]; then
   rm -rf target/
   cargo build --release --example heroku-deploy
   mkdir -p target/release
-  find "$CARGO_TARGET_DIR/release" -maxdepth 1 -type f -executable -exec cp -a -t target/release {} \;
 else
   echo "-----> Skipping Cargo build"
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -138,6 +138,7 @@ if [ $RUST_SKIP_BUILD -ne 1 ]; then
   cd "$BUILD_DIR/$BUILD_PATH"
   rm -rf target/
   cargo build --release --example heroku-deploy
+  ls target/release/examples/
 else
   echo "-----> Skipping Cargo build"
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -138,7 +138,6 @@ if [ $RUST_SKIP_BUILD -ne 1 ]; then
   cd "$BUILD_DIR/$BUILD_PATH"
   rm -rf target/
   cargo build --release --example heroku-deploy
-  mkdir -p target/release
 else
   echo "-----> Skipping Cargo build"
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -137,7 +137,7 @@ if [ $RUST_SKIP_BUILD -ne 1 ]; then
   echo "-----> Building application using Cargo"
   cd "$BUILD_DIR/$BUILD_PATH"
   rm -rf target/
-  cargo build $RUST_CARGO_BUILD_FLAGS
+  cargo build --release --example heroku-deploy
   mkdir -p target/release
   find "$CARGO_TARGET_DIR/release" -maxdepth 1 -type f -executable -exec cp -a -t target/release {} \;
 else

--- a/bin/compile
+++ b/bin/compile
@@ -33,7 +33,7 @@ RUST_INSTALL_DIESEL=0
 # These flags are passed to `cargo install diesel`, e.g. '--no-default-features --features postgres'
 DIESEL_FLAGS=""
 # Default build flags to pass to `cargo build`.
-RUST_CARGO_BUILD_FLAGS="--release --example heroku-deploy"
+RUST_CARGO_BUILD_FLAGS="--release"
 
 # Load our toolchain configuration, if any was specified.
 if [ -f "$BUILD_DIR/rust-toolchain" ]; then
@@ -137,7 +137,7 @@ if [ $RUST_SKIP_BUILD -ne 1 ]; then
   echo "-----> Building application using Cargo"
   cd "$BUILD_DIR/$BUILD_PATH"
   rm -rf target/
-  cargo build --release --example heroku-deploy
+  cargo build $RUST_CARGO_BUILD_FLAGS
   mkdir -p target/release
   find "$CARGO_TARGET_DIR/release" -maxdepth 2 -type f -executable -exec cp -a -t target/release {} \;
   ls target/release/

--- a/bin/compile
+++ b/bin/compile
@@ -139,7 +139,7 @@ if [ $RUST_SKIP_BUILD -ne 1 ]; then
   rm -rf target/
   cargo build --release --example heroku-deploy
   mkdir -p target/release
-  find "$CARGO_TARGET_DIR/release" -maxdepth 1 -type f -executable -exec cp -a -t target/release {} \;
+  find "$CARGO_TARGET_DIR/release" -maxdepth 2 -type f -executable -exec cp -a -t target/release {} \;
   ls target/release/
 else
   echo "-----> Skipping Cargo build"


### PR DESCRIPTION
When building with `cargo build --example whatever`, cargo places the resulting binary into `target/release/examples/whatever`. The `find` command's argument, maxdepth is set at 1, which excluded the examples directory. Changing this to 2 lets `find` look into the `example` directory.