### PR TITLE
Cope with CARGO_HOME existing, but not rustup

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -101,7 +101,7 @@ mkdir -p "$CACHE_DIR"
 cd "$CACHE_DIR"
 
 # Make sure we have an appropriate Rust toolchain installed.
-if [ -d "$CARGO_HOME" ]; then
+if which rustup; then
     echo "-----> Checking for new releases of Rust $VERSION channel"
     # It's possible that $VERSION has changed, or the `stable` channel has updated.
     rustup self update


### PR DESCRIPTION
Was upgrading an app that used https://github.com/Hoverbear/heroku-buildpack-rust before and got the error
```
-----> Checking for new releases of Rust stable channel        
/tmp/buildpacks/custom/bin/compile: line 107: rustup: command not found  
```

This fixes the rustup detection